### PR TITLE
Push enhancements

### DIFF
--- a/push.go
+++ b/push.go
@@ -61,7 +61,7 @@ func configurePushCommand(app *kingpin.Application) {
 
 func (cmd *PushCommand) push(context *kingpin.ParseContext) error {
 	appPath := cmd.appPath
-	noPolling := cmd.noPolling
+	pollingEnabled := !cmd.noPolling
 	waitInSeconds := cmd.waitInSeconds
 
 	appPath, appName, appManifestFile, err := prepareAppUpload(cmd.appPath)
@@ -108,7 +108,7 @@ func (cmd *PushCommand) push(context *kingpin.ParseContext) error {
 		return err
 	}
 
-	if !noPolling {
+	if pollingEnabled {
 		doPolling(pollURI, waitInSeconds)
 	}
 

--- a/push.go
+++ b/push.go
@@ -37,6 +37,7 @@ const (
 	pushTemplateURI    = "%s/files/push/%s?sessionid=%s"
 	pollClientTimeout  = 5 * time.Second
 	pollInterval       = 5 * time.Second // how often to poll status URL
+	uploadTimeout      = 1 * time.Minute
 	pollFinishedStatus = "FINISHED"
 	pollFailedStatus   = "FAILED"
 )
@@ -97,55 +98,90 @@ func (cmd *PushCommand) push(context *kingpin.ParseContext) error {
 		return err
 	}
 
-	finished := false
-	var statusResponse pushPollResponse
-	timeout := time.Duration(pollClientTimeout)
-	client := http.Client{Timeout: timeout}
+	doPolling(pollURI)
 
-	for !finished {
-		resp, err := client.Get(pollURI)
-		if err != nil {
-			log.Println("Error. during polling push to the frontend")
-			return err
-		}
+	return nil
+}
 
-		err = json.NewDecoder(resp.Body).Decode(&statusResponse)
-		resp.Body.Close()
+func doPolling(pollURI string) {
+	quit := make(chan interface{}, 1)
+	defer close(quit)
 
-		if err != nil {
-			log.Println("Error. during parsing poll status result")
-			bodyData, _ := ioutil.ReadAll(resp.Body)
-			if bodyData != nil {
-				log.Println(bodyData)
-			}
-			return err
-		}
+	progressMonitor := verifyProgress(pollURI, quit)
 
-		log.Printf("Pushing to the website to the development environment, status: [%s]", statusResponse.Meta.Status)
-
-		if statusResponse.Meta.Status == pollFinishedStatus || statusResponse.Meta.Status == pollFailedStatus {
-			finished = true
+	select {
+	case statusResponse, ok := <-progressMonitor:
+		if !ok {
 			break
 		}
 
-		time.Sleep(pollInterval)
+		log.Printf("Server output for the app bundling:")
+		for _, message := range statusResponse.Meta.Messages {
+			log.Printf("Widget: %s", message.Widget)
+			log.Printf("Output: %s", message.Output)
+		}
+
+		if statusResponse.Meta.Status == pollFinishedStatus {
+			log.Printf("App successfully pushed. The frontend for this development session is at %s", statusResponse.Links.Preview)
+		} else {
+			log.Printf("App push failed.")
+		}
+
+		openWebsite(statusResponse.Links.Preview)
+		close(progressMonitor)
+
+	case <-time.After(uploadTimeout):
+		quit <- true // send a cancel signal to progressMonitor
+		log.Printf("Operation timed out after %s", uploadTimeout)
 	}
+}
 
-	log.Printf("Server output for the app bundling:")
-	for _, message := range statusResponse.Meta.Messages {
-		log.Printf("Widget: %s", message.Widget)
-		log.Printf("Output: %s", message.Output)
-	}
+func verifyProgress(pollURI string, quit <-chan interface{}) chan pushPollResponse {
+	done := make(chan pushPollResponse, 1)
+	go func() {
+		var statusResponse pushPollResponse
+		timeout := time.Duration(pollClientTimeout)
+		client := http.Client{Timeout: timeout}
 
-	if statusResponse.Meta.Status == pollFinishedStatus {
-		log.Printf("App successfully pushed. The frontend for this development session is at %s", statusResponse.Links.Preview)
-	} else {
-		log.Printf("App push failed.")
-	}
+		for {
+			// check if operation should be cancelled
+			select {
+			case <-quit:
+				return
+			default:
+			}
 
-	openWebsite(statusResponse.Links.Preview)
+			resp, err := client.Get(pollURI)
+			if err != nil {
+				log.Println("Error. during polling push to the frontend")
+				close(done)
+				return
+			}
 
-	return nil
+			err = json.NewDecoder(resp.Body).Decode(&statusResponse)
+			resp.Body.Close()
+
+			if err != nil {
+				log.Println("Error. during parsing poll status result")
+				bodyData, _ := ioutil.ReadAll(resp.Body)
+				if bodyData != nil {
+					log.Println(bodyData)
+				}
+				close(done)
+				return
+			}
+
+			log.Printf("Pushing to the website to the development environment, status: [%s]", statusResponse.Meta.Status)
+
+			if statusResponse.Meta.Status == pollFinishedStatus || statusResponse.Meta.Status == pollFailedStatus {
+				done <- statusResponse
+				break
+			}
+
+			time.Sleep(pollInterval)
+		}
+	}()
+	return done
 }
 
 func pushToCatalog(pushURI string, appManifestFile string) (uploadURI string, err error) {


### PR DESCRIPTION
## What's changed

1. The polling operation will terminate after the wait time specified in argument `--wait` (default 180 seconds)
1. Created a `--noPolling` flag so user can skip polling operation altogether

