### PR TITLE
Add local flag to force uploading to local frontend

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,8 +14,9 @@ var (
 		"staging": "https://appcatalog.staging.travix.com",
 		"prod":    "https://appcatalog.travix.com",
 	}
-	targetEnv = "dev"
-	verbose   = false
+	targetEnv     = "dev"
+	verbose       = false
+	localFrontend = false
 )
 
 func main() {
@@ -27,6 +28,9 @@ func main() {
 	app.Flag("verbose", "Verbose mode.").
 		Short('v').
 		BoolVar(&verbose)
+
+	app.Flag("local", "Upload to the local RWD frontend instead of the one returned by the catalog.").
+		BoolVar(&localFrontend)
 
 	configureInitCommand(app)
 	configurePushCommand(app)

--- a/mybuild.sh
+++ b/mybuild.sh
@@ -1,1 +1,0 @@
-go build -o ~/.appix/appix -i .

--- a/mybuild.sh
+++ b/mybuild.sh
@@ -1,0 +1,1 @@
+go build -o ~/.appix/appix -i .

--- a/push.go
+++ b/push.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"os/exec"
+	"regexp"
 	"runtime"
 	"time"
 
@@ -91,6 +92,16 @@ func (cmd *PushCommand) push(context *kingpin.ParseContext) error {
 	pushURI := fmt.Sprintf(pushTemplateURI, rootURI, appName, sessionID)
 
 	uploadURI, err := pushToCatalog(pushURI, appManifestFile)
+
+	if localFrontend {
+		reg, err := regexp.Compile(`(https?:\/\/.*)(\/.*)`)
+		if err != nil {
+			log.Println(err)
+			return err
+		}
+
+		uploadURI = reg.ReplaceAllString(uploadURI, "http://localhost:3001$2")
+	}
 
 	if err != nil {
 		log.Println("Error during pushing the manifest to the App Catalog.")


### PR DESCRIPTION
With this PR if we do `appix push --local` it will upload to the rwd instance running on localhost instead of the one returned by the catalog (which is usually `https://fireball-dev.development.travix.com/`).