### PR TITLE
Fix - Do not open frontend if `push` fails

### DIFF
--- a/push.go
+++ b/push.go
@@ -147,12 +147,11 @@ func doPolling(pollURI string, waitInSeconds int) {
 
 		if statusResponse.Meta.Status == pollFinishedStatus {
 			log.Printf("App successfully pushed. The frontend for this development session is at %s", statusResponse.Links.Preview)
+			openWebsite(statusResponse.Links.Preview)
 		} else {
 			log.Printf("App push failed.")
-			break
 		}
 
-		openWebsite(statusResponse.Links.Preview)
 		close(progressMonitor)
 
 	case <-time.After(wait):

--- a/push.go
+++ b/push.go
@@ -149,6 +149,7 @@ func doPolling(pollURI string, waitInSeconds int) {
 			log.Printf("App successfully pushed. The frontend for this development session is at %s", statusResponse.Links.Preview)
 		} else {
 			log.Printf("App push failed.")
+			break
 		}
 
 		openWebsite(statusResponse.Links.Preview)


### PR DESCRIPTION
# What's changed

If `appix push` command fails, it should not open front-end.