### PR TITLE
TR-12144 Rename publish to submit, and change the default catalog to production

### DIFF
--- a/developmentSettings.go
+++ b/developmentSettings.go
@@ -20,7 +20,7 @@ type DevelopmentSettings struct {
 }
 
 // DevFileName is the name of the file which contains the appix development settings for this specific application
-const DevFileName = ".appixDevSettings" // Exported for blacklisting use during push/publish
+const DevFileName = ".appixDevSettings" // Exported for blacklisting use during push/submit
 
 func readDevelopmentSettings(appPath string) (*DevelopmentSettings, error) {
 	devSettingsPath := path.Join(appPath, DevFileName)

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ var (
 		"staging": "https://appcatalog.staging.travix.com",
 		"prod":    "https://appcatalog.travix.com",
 	}
-	targetEnv     = "staging"
+	targetEnv     = "prod"
 	verbose       = false
 	localFrontend = false
 )
@@ -23,7 +23,7 @@ func main() {
 	app := kingpin.New("appix", "App Developer Kit for the Travix Fireball infrastructure.")
 
 	app.Flag("cat", "Specify the catalog to use (local, dev, staging, prod)").
-		Default("staging").
+		Default("prod").
 		EnumVar(&targetEnv, "local", "dev", "staging", "prod")
 	app.Flag("verbose", "Verbose mode.").
 		Short('v').
@@ -34,7 +34,7 @@ func main() {
 
 	configureInitCommand(app)
 	configurePushCommand(app)
-	configurePublishCommand(app)
+	configureSubmitCommand(app)
 
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 }


### PR DESCRIPTION
We decided to rename "publish" to "submit" some time ago, but didn't get around to actually implement it, this PR does it.

Also, in this PR we're changing the default catalog to production.

This will be merged only after communicating this change to the other teams.