### PR TITLE
Authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,6 @@ deploy:
   on:
     repo: Travix-International/Travix.Core.Adk
     tags: true # The deployment happens only if the commit has a tag.
+
+notifications:
+  email: false

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,17 @@
+# Maintainers
+
+## Travis-CI
+
+We use Travis for generating our executables automatically. To successfully build it, we need to make sure these environment variables are set there:
+
+```
+export TRAVIX_FIREBASE_API_KEY=""
+export TRAVIX_FIREBASE_AUTH_DOMAIN=""
+export TRAVIX_FIREBASE_DATABASE_URL=""
+export TRAVIX_FIREBASE_STORAGE_BUCKET=""
+export TRAVIX_FIREBASE_MESSAGING_SENDER_ID=""
+
+export TRAVIX_DEVELOPER_PROFILE_URL=""
+```
+
+You can set them here: [https://travis-ci.org/Travix-International/Travix.Core.Adk/settings](https://travis-ci.org/Travix-International/Travix.Core.Adk/settings)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
-# Travix Fireball ADK 
+# Travix Fireball ADK
 
-App Developer Kit for the Travix Fireball infrastructure. The ADK consists of `appix`, a CLI tool to publish Apps to the App Catalog. 
+App Developer Kit for the Travix Fireball infrastructure. The ADK consists of `appix`, a CLI tool to publish Apps to the App Catalog.
 
 [![Build Status](https://travis-ci.org/Travix-International/Travix.Core.Adk.svg?branch=master)](https://travis-ci.org/Travix-International/Travix.Core.Adk)
 [![GitHub release](https://img.shields.io/github/release/Travix-International/Travix.Core.Adk.svg)](https://github.com/Travix-International/Travix.Core.Adk/releases/latest)
 
 ## Installation
+
 The ADK can be used on either Windows, Linux and Mac. There are separate installation scripts for Windows and Linux/Mac.
 
 ### Windows
+
 To install the latest version on Windows, execute the following command in a PowerShell window.
 
 ```
@@ -22,23 +24,74 @@ $env:APPIX_VERSION='1.0.0.5'
 iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/Travix-International/Travix.Core.Adk/master/appixinstall.ps1'))
 ```
 
-### Linux and Mac
+### Linux and macOS
 
 To install the latest version, run the following command in a terminal.
 
 ```
-curl -sSL https://raw.githubusercontent.com/Travix-International/Travix.Core.Adk/master/appixinstall.sh | sh
+$ curl -sSL https://raw.githubusercontent.com/Travix-International/Travix.Core.Adk/master/appixinstall.sh | sh
 ```
 
 To install a specific version of the ADK, run the following command.
 
 ```
-curl -sSL https://raw.githubusercontent.com/Travix-International/Travix.Core.Adk/master/appixinstall.sh | APPIX_VERSION=1.0.0.5 sh
+$ curl -sSL https://raw.githubusercontent.com/Travix-International/Travix.Core.Adk/master/appixinstall.sh | APPIX_VERSION=1.0.0.5 sh
 ```
 
 ## Getting started
 
 After installation, the ADK can be run by typing `appix` in the terminal. Run `appix --help` to view the available commands and usage.
+
+## Development
+
+For developing the ADK itself:
+
+### Clone
+
+Clone the repo to your `$GOPATH`:
+
+```
+$ git clone git@github.com:Travix-International/Travix.Core.Adk.git $GOPATH/src/Travix-International/Travix.Core.Adk
+```
+
+### Depedencies
+
+Install the dependencies with [gvt](https://github.com/FiloSottile/gvt):
+
+```
+$ cd $GOPATH/src/Travix-International/Travix.Core.Adk
+$ gvt restore
+```
+
+### Environment variables
+
+Make sure you have these environment variables (usually in your `~/.bash_profile` file) with the correct values:
+
+```
+export TRAVIX_FIREBASE_API_KEY=""
+export TRAVIX_FIREBASE_AUTH_DOMAIN=""
+export TRAVIX_FIREBASE_DATABASE_URL=""
+export TRAVIX_FIREBASE_STORAGE_BUCKET=""
+export TRAVIX_FIREBASE_MESSAGING_SENDER_ID=""
+
+export TRAVIX_DEVELOPER_PROFILE_URL=""
+```
+
+### Build
+
+Running this would generate `./bin/appix-mac` (if you are on macOS):
+
+```
+$ ./build.sh
+```
+
+Furthermore, you can copy it to the local appix path for easy access:
+
+```
+$ cp ./bin/appix-mac ~/.appix/appix
+```
+
+Now you can execute it as `$ appix` as usual.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Clone the repo to your `$GOPATH`:
 $ git clone git@github.com:Travix-International/Travix.Core.Adk.git $GOPATH/src/Travix-International/Travix.Core.Adk
 ```
 
-### Depedencies
+### Dependencies
 
 Install the dependencies with [gvt](https://github.com/FiloSottile/gvt):
 

--- a/authServer.go
+++ b/authServer.go
@@ -132,21 +132,6 @@ func startAuthServer(c chan bool, config Config) {
 								content: JSON.stringify(result, null, 2)
 							});
 						}
-					})
-					.catch(function (error) {
-						console.log('error', error);
-
-						// Handle Errors here.
-						var errorCode = error.code;
-						var errorMessage = error.message;
-
-						// The email of the user's account used.
-						var email = error.email;
-
-						// The firebase.auth.AuthCredential type that was used.
-						var credential = error.credential;
-
-						// ...
 					});
 				</script>
 			</head>
@@ -174,7 +159,7 @@ func startAuthServer(c chan bool, config Config) {
 			panic(writeErr)
 		}
 
-		io.WriteString(w, "File written at: "+config.AuthFilePath)
+		io.WriteString(w, "Login successful! You can close your browser tab now.")
 		c <- true
 	})
 

--- a/authServer.go
+++ b/authServer.go
@@ -69,7 +69,7 @@ func GetAuth(c Config) (*Auth, error) {
 	return &auth, nil
 }
 
-func startAuthServer(c chan bool, config Config) {
+func startAuthServer(c chan interface{}, config Config) {
 	firebaseConfig := `
 		<script src="https://www.gstatic.com/firebasejs/3.6.0/firebase.js"></script>
 		<script>
@@ -149,7 +149,9 @@ func startAuthServer(c chan bool, config Config) {
 
 	http.HandleFunc("/success", func(w http.ResponseWriter, r *http.Request) {
 		io.WriteString(w, "Login successful! You can close your browser tab now.")
-		c <- true
+
+		// this would close the server
+		c <- nil
 	})
 
 	http.ListenAndServe(":"+config.AuthServerPort, nil)

--- a/authServer.go
+++ b/authServer.go
@@ -23,31 +23,31 @@ func createAuthFileIfNotExists(c Config) error {
 }
 
 type StsTokenManager struct {
-	ApiKey string
-	RefreshToken string
-	AccessToken string
+	ApiKey         string
+	RefreshToken   string
+	AccessToken    string
 	ExpirationTime int
 }
 
 type AuthUser struct {
-	Uid string
-	DisplayName string
-	Email string
-	EmailVerified bool
-	ApiKey string
-	AppName string
-	AuthDomain string
+	Uid             string
+	DisplayName     string
+	Email           string
+	EmailVerified   bool
+	ApiKey          string
+	AppName         string
+	AuthDomain      string
 	StsTokenManager StsTokenManager
 }
 
 type AuthCredential struct {
-	IdToken string
+	IdToken     string
 	AccessToken string
-	Provider string
+	Provider    string
 }
 
 type Auth struct {
-	User AuthUser
+	User       AuthUser
 	Credential AuthCredential
 }
 
@@ -174,9 +174,9 @@ func startAuthServer(c chan bool, config Config) {
 			panic(writeErr)
 		}
 
-		io.WriteString(w, "File written at: " + config.AuthFilePath)
+		io.WriteString(w, "File written at: "+config.AuthFilePath)
 		c <- true
 	})
 
-	http.ListenAndServe(":" + config.AuthServerPort, nil)
+	http.ListenAndServe(":"+config.AuthServerPort, nil)
 }

--- a/authServer.go
+++ b/authServer.go
@@ -43,6 +43,21 @@ type Auth struct {
 	Credential AuthCredential
 }
 
+type Profile struct {
+	Email string
+	FirebaseUserId string
+	Id int
+	IsEnabled bool
+	IsVerified bool
+	Name string
+	PublisherId string
+}
+
+type ProfileResponse struct {
+	HasProfile bool
+	Profile Profile
+}
+
 func GetAuth(c Config) (*Auth, error) {
 	content, readErr := ioutil.ReadFile(c.AuthFilePath)
 	if readErr != nil {

--- a/authServer.go
+++ b/authServer.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+)
+
+func createAuthFileIfNotExists(c Config) error {
+	var _, statErr = os.Stat(c.AuthFilePath)
+	if os.IsNotExist(statErr) {
+		fmt.Println("File does not exist, creating...")
+		var _, createErr = os.Create(c.AuthFilePath)
+
+		return createErr
+	}
+
+	return nil
+}
+
+func startAuthServer(c chan bool) {
+	var config = GetConfig()
+
+	firebaseConfig := `
+		<script src="https://www.gstatic.com/firebasejs/3.6.0/firebase.js"></script>
+		<script>
+		// Initialize Firebase
+		var config = {
+			apiKey: "` + config.FirebaseApiKey + `",
+			authDomain: "` + config.FirebaseAuthDomain + `",
+			databaseURL: "` + config.FirebaseDatabaseUrl + `",
+			storageBucket: "` + config.FirebaseStorageBucket + `",
+			messagingSenderId: "` + config.FirebaseMessagingSenderId + `"
+		};
+		firebase.initializeApp(config);
+
+		var provider = new firebase.auth.GoogleAuthProvider();
+		provider.addScope('https://www.googleapis.com/auth/plus.login');
+		provider.setCustomParameters({
+			'login_hint': 'user@travix.com'
+		});
+		</script>`
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		html := `
+		<!DOCTYPE html>
+		<html>
+			<head>
+				` + firebaseConfig + `
+
+				<script>
+				function loginWithGoogle() {
+					firebase.auth().signInWithRedirect(provider);
+				}
+
+				function postData(path, params) {
+					var method = "post";
+
+					var form = document.createElement("form");
+					form.setAttribute("method", method);
+					form.setAttribute("action", path);
+
+					for (var key in params) {
+						if (params.hasOwnProperty(key)) {
+							var hiddenField = document.createElement("input");
+
+							hiddenField.setAttribute("type", "hidden");
+							hiddenField.setAttribute("name", key);
+							hiddenField.setAttribute("value", params[key]);
+
+							form.appendChild(hiddenField);
+						}
+					}
+
+					document.body.appendChild(form);
+					form.submit();
+				}
+
+				firebase.auth().getRedirectResult()
+					.then(function (result) {
+						if (result.credential) {
+							postData('/save', {
+								content: JSON.stringify(result, null, 2)
+							});
+						}
+					})
+					.catch(function (error) {
+						console.log('error', error);
+
+						// Handle Errors here.
+						var errorCode = error.code;
+						var errorMessage = error.message;
+
+						// The email of the user's account used.
+						var email = error.email;
+
+						// The firebase.auth.AuthCredential type that was used.
+						var credential = error.credential;
+
+						// ...
+					});
+				</script>
+			</head>
+
+			<body>
+				<a href="#" onClick="javascript: loginWithGoogle()">
+					Login with Google
+				</a>
+			</body>
+		</html>`
+
+		io.WriteString(w, html)
+	})
+
+	http.HandleFunc("/save", func(w http.ResponseWriter, r *http.Request) {
+		var createErr = createAuthFileIfNotExists(config)
+		if createErr != nil {
+			panic(createErr)
+		}
+
+		formContent := r.FormValue("content")
+		content := []byte(formContent)
+		writeErr := ioutil.WriteFile(config.AuthFilePath, content, 0644)
+		if writeErr != nil {
+			panic(writeErr)
+		}
+
+		io.WriteString(w, "File written at: " + config.AuthFilePath)
+		c <- true
+	})
+
+	http.ListenAndServe(":7001", nil)
+}

--- a/authServer.go
+++ b/authServer.go
@@ -22,6 +22,13 @@ func createAuthFileIfNotExists(c Config) error {
 	return nil
 }
 
+type StsTokenManager struct {
+	ApiKey string
+	RefreshToken string
+	AccessToken string
+	ExpirationTime int
+}
+
 type AuthUser struct {
 	Uid string
 	DisplayName string
@@ -30,6 +37,7 @@ type AuthUser struct {
 	ApiKey string
 	AppName string
 	AuthDomain string
+	StsTokenManager StsTokenManager
 }
 
 type AuthCredential struct {
@@ -41,21 +49,6 @@ type AuthCredential struct {
 type Auth struct {
 	User AuthUser
 	Credential AuthCredential
-}
-
-type Profile struct {
-	Email string
-	FirebaseUserId string
-	Id int
-	IsEnabled bool
-	IsVerified bool
-	Name string
-	PublisherId string
-}
-
-type ProfileResponse struct {
-	HasProfile bool
-	Profile Profile
 }
 
 func GetAuth(c Config) (*Auth, error) {

--- a/build.ps1
+++ b/build.ps1
@@ -17,7 +17,16 @@ if (Test-Path env:APPVEYOR_BUILD_VERSION) {
     $GIT_HASH = "000"
 }
 $BUILD_DATE = (Get-Date -Date ((Get-Date).ToUniversalTime()) -UFormat %a.%B.%d.%Y.%R:%S) + ".+0000.UTC"
-$APP_LDFLAGS="-s -X main.version=$BUILD_VERSION -X main.gitHash=$GIT_HASH -X main.buildDate=$BUILD_DATE -X main.travixFirebaseApiKey=$TRAVIX_FIREBASE_API_KEY -X main.travixFirebaseAuthDomain=$TRAVIX_FIREBASE_AUTH_DOMAIN -X main.travixFirebaseDatabaseUrl=$TRAVIX_FIREBASE_DATABASE_URL -X main.travixFirebaseStorageBucket=$TRAVIX_FIREBASE_STORAGE_BUCKET -X main.travixFirebaseMessagingSenderId=$TRAVIX_FIREBASE_MESSAGING_SENDER_ID -X main.travixDeveloperProfileUrl=$TRAVIX_DEVELOPER_PROFILE_URL"
+$APP_LDFLAGS="-s
+-X main.version=$BUILD_VERSION
+-X main.gitHash=$GIT_HASH
+-X main.buildDate=$BUILD_DATE
+-X main.travixFirebaseApiKey=$TRAVIX_FIREBASE_API_KEY
+-X main.travixFirebaseAuthDomain=$TRAVIX_FIREBASE_AUTH_DOMAIN
+-X main.travixFirebaseDatabaseUrl=$TRAVIX_FIREBASE_DATABASE_URL
+-X main.travixFirebaseStorageBucket=$TRAVIX_FIREBASE_STORAGE_BUCKET
+-X main.travixFirebaseMessagingSenderId=$TRAVIX_FIREBASE_MESSAGING_SENDER_ID
+-X main.travixDeveloperProfileUrl=$TRAVIX_DEVELOPER_PROFILE_URL"
 Write-Output "Load flags will be $APP_LDFLAGS"
 Write-Output "AV vars are $env:APPVEYOR_BUILD_VERSION / $env:APPVEYOR_REPO_COMMIT"
 

--- a/build.ps1
+++ b/build.ps1
@@ -17,7 +17,7 @@ if (Test-Path env:APPVEYOR_BUILD_VERSION) {
     $GIT_HASH = "000"
 }
 $BUILD_DATE = (Get-Date -Date ((Get-Date).ToUniversalTime()) -UFormat %a.%B.%d.%Y.%R:%S) + ".+0000.UTC"
-$APP_LDFLAGS="-s -X main.version=$BUILD_VERSION -X main.gitHash=$GIT_HASH -X main.buildDate=$BUILD_DATE"
+$APP_LDFLAGS="-s -X main.version=$BUILD_VERSION -X main.gitHash=$GIT_HASH -X main.buildDate=$BUILD_DATE -X main.travixFirebaseApiKey=$TRAVIX_FIREBASE_API_KEY -X main.travixFirebaseAuthDomain=$TRAVIX_FIREBASE_AUTH_DOMAIN -X main.travixFirebaseDatabaseUrl=$TRAVIX_FIREBASE_DATABASE_URL -X main.travixFirebaseStorageBucket=$TRAVIX_FIREBASE_STORAGE_BUCKET -X main.travixFirebaseMessagingSenderId=$TRAVIX_FIREBASE_MESSAGING_SENDER_ID -X main.travixDeveloperProfileUrl=$TRAVIX_DEVELOPER_PROFILE_URL"
 Write-Output "Load flags will be $APP_LDFLAGS"
 Write-Output "AV vars are $env:APPVEYOR_BUILD_VERSION / $env:APPVEYOR_REPO_COMMIT"
 

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,16 @@ set -euf -o pipefail
 BUILD_DATE=`LC_ALL=en_US.utf8 date -u +"%a.%B.%d.%Y.%R:%S.%z.%Z"`
 : "${TRAVIS_TAG:=0.0.0}"
 : "${TRAVIS_COMMIT:=`git rev-parse --short HEAD`}"
-APP_LDFLAGS="-s -X main.version=$TRAVIS_TAG -X main.gitHash=$TRAVIS_COMMIT -X main.buildDate=$BUILD_DATE -X main.travixFirebaseApiKey=$TRAVIX_FIREBASE_API_KEY -X main.travixFirebaseAuthDomain=$TRAVIX_FIREBASE_AUTH_DOMAIN -X main.travixFirebaseDatabaseUrl=$TRAVIX_FIREBASE_DATABASE_URL -X main.travixFirebaseStorageBucket=$TRAVIX_FIREBASE_STORAGE_BUCKET -X main.travixFirebaseMessagingSenderId=$TRAVIX_FIREBASE_MESSAGING_SENDER_ID -X main.travixDeveloperProfileUrl=$TRAVIX_DEVELOPER_PROFILE_URL"
+APP_LDFLAGS="-s
+-X main.version=$TRAVIS_TAG
+-X main.gitHash=$TRAVIS_COMMIT
+-X main.buildDate=$BUILD_DATE
+-X main.travixFirebaseApiKey=$TRAVIX_FIREBASE_API_KEY
+-X main.travixFirebaseAuthDomain=$TRAVIX_FIREBASE_AUTH_DOMAIN
+-X main.travixFirebaseDatabaseUrl=$TRAVIX_FIREBASE_DATABASE_URL
+-X main.travixFirebaseStorageBucket=$TRAVIX_FIREBASE_STORAGE_BUCKET
+-X main.travixFirebaseMessagingSenderId=$TRAVIX_FIREBASE_MESSAGING_SENDER_ID
+-X main.travixDeveloperProfileUrl=$TRAVIX_DEVELOPER_PROFILE_URL"
 
 echo "Building Windows binary..."
 GOARCH=amd64 GOOS=windows go build -ldflags "$APP_LDFLAGS" -o bin/appix.exe -i .

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -euf -o pipefail
 BUILD_DATE=`LC_ALL=en_US.utf8 date -u +"%a.%B.%d.%Y.%R:%S.%z.%Z"`
 : "${TRAVIS_TAG:=0.0.0}"
 : "${TRAVIS_COMMIT:=`git rev-parse --short HEAD`}"
-APP_LDFLAGS="-s -X main.version=$TRAVIS_TAG -X main.gitHash=$TRAVIS_COMMIT -X main.buildDate=$BUILD_DATE"
+APP_LDFLAGS="-s -X main.version=$TRAVIS_TAG -X main.gitHash=$TRAVIS_COMMIT -X main.buildDate=$BUILD_DATE -X main.travixFirebaseApiKey=$TRAVIX_FIREBASE_API_KEY -X main.travixFirebaseAuthDomain=$TRAVIX_FIREBASE_AUTH_DOMAIN -X main.travixFirebaseDatabaseUrl=$TRAVIX_FIREBASE_DATABASE_URL -X main.travixFirebaseStorageBucket=$TRAVIX_FIREBASE_STORAGE_BUCKET -X main.travixFirebaseMessagingSenderId=$TRAVIX_FIREBASE_MESSAGING_SENDER_ID -X main.travixDeveloperProfileUrl=$TRAVIX_DEVELOPER_PROFILE_URL"
 
 echo "Building Windows binary..."
 GOARCH=amd64 GOOS=windows go build -ldflags "$APP_LDFLAGS" -o bin/appix.exe -i .
@@ -14,6 +14,6 @@ echo "Building Mac binary..."
 GOARCH=amd64 GOOS=darwin go build -ldflags "$APP_LDFLAGS" -o bin/appix-mac -i .
 
 echo "Building Linux binary..."
-GOARCH=amd64 GOOS=linux go build -ldflags "$APP_LDFLAGS" -o bin/appix-linux -i . 
+GOARCH=amd64 GOOS=linux go build -ldflags "$APP_LDFLAGS" -o bin/appix-linux -i .
 
 echo "Done!"

--- a/config.go
+++ b/config.go
@@ -10,6 +10,8 @@ type Config struct {
 	DirectoryPath string
 	AuthFilePath string
 
+	DeveloperProfileUrl string
+
 	FirebaseApiKey string
 	FirebaseAuthDomain string
 	FirebaseDatabaseUrl string
@@ -30,6 +32,8 @@ func GetConfig() Config {
 	c := Config{
 		DirectoryPath: directoryPath,
 		AuthFilePath: filepath.Join(directoryPath, "auth.json"),
+
+		DeveloperProfileUrl: "",
 
 		FirebaseApiKey: "",
 		FirebaseAuthDomain: "",

--- a/config.go
+++ b/config.go
@@ -1,21 +1,21 @@
 package main
 
 import (
-	"os/user"
 	"log"
+	"os/user"
 	"path/filepath"
 )
 
 type Config struct {
 	DirectoryPath string
-	AuthFilePath string
+	AuthFilePath  string
 
 	DeveloperProfileUrl string
 
-	FirebaseApiKey string
-	FirebaseAuthDomain string
-	FirebaseDatabaseUrl string
-	FirebaseStorageBucket string
+	FirebaseApiKey            string
+	FirebaseAuthDomain        string
+	FirebaseDatabaseUrl       string
+	FirebaseStorageBucket     string
 	FirebaseMessagingSenderId string
 
 	AuthServerPort string
@@ -31,14 +31,14 @@ func GetConfig() Config {
 
 	c := Config{
 		DirectoryPath: directoryPath,
-		AuthFilePath: filepath.Join(directoryPath, "auth.json"),
+		AuthFilePath:  filepath.Join(directoryPath, "auth.json"),
 
 		DeveloperProfileUrl: "",
 
-		FirebaseApiKey: "",
-		FirebaseAuthDomain: "",
-		FirebaseDatabaseUrl: "",
-		FirebaseStorageBucket: "",
+		FirebaseApiKey:            "",
+		FirebaseAuthDomain:        "",
+		FirebaseDatabaseUrl:       "",
+		FirebaseStorageBucket:     "",
 		FirebaseMessagingSenderId: "",
 
 		AuthServerPort: "7001",

--- a/config.go
+++ b/config.go
@@ -33,13 +33,13 @@ func GetConfig() Config {
 		DirectoryPath: directoryPath,
 		AuthFilePath:  filepath.Join(directoryPath, "auth.json"),
 
-		DeveloperProfileUrl: "",
+		DeveloperProfileUrl: travixDeveloperProfileUrl,
 
-		FirebaseApiKey:            "",
-		FirebaseAuthDomain:        "",
-		FirebaseDatabaseUrl:       "",
-		FirebaseStorageBucket:     "",
-		FirebaseMessagingSenderId: "",
+		FirebaseApiKey:            travixFirebaseApiKey,
+		FirebaseAuthDomain:        travixFirebaseAuthDomain,
+		FirebaseDatabaseUrl:       travixFirebaseDatabaseUrl,
+		FirebaseStorageBucket:     travixFirebaseStorageBucket,
+		FirebaseMessagingSenderId: travixFirebaseMessagingSenderId,
 
 		AuthServerPort: "7001",
 	}

--- a/config.go
+++ b/config.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os/user"
+	"log"
+	"path/filepath"
+)
+
+type Config struct {
+	DirectoryPath string
+	AuthFilePath string
+
+	FirebaseApiKey string
+	FirebaseAuthDomain string
+	FirebaseDatabaseUrl string
+	FirebaseStorageBucket string
+	FirebaseMessagingSenderId string
+
+	AuthServerPort string
+}
+
+func GetConfig() Config {
+	user, userErr := user.Current()
+	if userErr != nil {
+		log.Fatal(userErr)
+	}
+
+	directoryPath := filepath.Join(user.HomeDir, ".appix")
+
+	c := Config{
+		DirectoryPath: directoryPath,
+		AuthFilePath: filepath.Join(directoryPath, "auth.json"),
+
+		FirebaseApiKey: "",
+		FirebaseAuthDomain: "",
+		FirebaseDatabaseUrl: "",
+		FirebaseStorageBucket: "",
+		FirebaseMessagingSenderId: "",
+
+		AuthServerPort: "7001",
+	}
+
+	return c
+}

--- a/login.go
+++ b/login.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"fmt"
+
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+)
+
+func configureLoginCommand(app *kingpin.Application) {
+	app.Command("login", "Login").
+		Action(executeLoginCommand)
+}
+
+func executeLoginCommand(context *kingpin.ParseContext) error {
+	fmt.Println("Login here...")
+	return nil
+}

--- a/login.go
+++ b/login.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
@@ -13,5 +15,39 @@ func configureLoginCommand(app *kingpin.Application) {
 
 func executeLoginCommand(context *kingpin.ParseContext) error {
 	fmt.Println("Login here...")
+	ch := make(chan bool)
+
+	go startLoginServer(ch)
+
+	openWebsite("http://localhost:7001")
+
+	select {
+	case shouldClose := <-ch:
+		if shouldClose {
+
+		} else {
+
+		}
+	}
+
 	return nil
 }
+
+func loginBaseRoute(w http.ResponseWriter, r *http.Request) {
+	io.WriteString(w, "Hello world from login server!")
+}
+
+func startLoginServer(c chan bool) {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "Hello world from login server!")
+	})
+
+	http.HandleFunc("/close", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "closing...")
+
+		c <- true
+	})
+
+	http.ListenAndServe(":7001", nil)
+}
+

--- a/login.go
+++ b/login.go
@@ -15,17 +15,15 @@ func executeLoginCommand(context *kingpin.ParseContext) error {
 	var config = GetConfig()
 	var url = "http://localhost:" + config.AuthServerPort
 
-	ch := make(chan bool)
+	ch := make(chan interface{})
 	go startAuthServer(ch, config)
 
 	fmt.Println("Opening url: " + url)
 	openWebsite(url)
 
 	select {
-	case shouldClose := <-ch:
-		if shouldClose {
-			fmt.Println("Closing server...")
-		}
+	case <-ch:
+		fmt.Println("Closing server...")
 	}
 
 	return nil

--- a/login.go
+++ b/login.go
@@ -30,4 +30,3 @@ func executeLoginCommand(context *kingpin.ParseContext) error {
 
 	return nil
 }
-

--- a/login.go
+++ b/login.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io"
-	"net/http"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
@@ -14,40 +12,22 @@ func configureLoginCommand(app *kingpin.Application) {
 }
 
 func executeLoginCommand(context *kingpin.ParseContext) error {
-	fmt.Println("Login here...")
+	var config = GetConfig()
+	var url = "http://localhost:" + config.AuthServerPort
+
 	ch := make(chan bool)
+	go startAuthServer(ch)
 
-	go startLoginServer(ch)
-
-	openWebsite("http://localhost:7001")
+	fmt.Println("Opening url: " + url)
+	openWebsite(url)
 
 	select {
 	case shouldClose := <-ch:
 		if shouldClose {
-
-		} else {
-
+			fmt.Println("Closing server...")
 		}
 	}
 
 	return nil
-}
-
-func loginBaseRoute(w http.ResponseWriter, r *http.Request) {
-	io.WriteString(w, "Hello world from login server!")
-}
-
-func startLoginServer(c chan bool) {
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		io.WriteString(w, "Hello world from login server!")
-	})
-
-	http.HandleFunc("/close", func(w http.ResponseWriter, r *http.Request) {
-		io.WriteString(w, "closing...")
-
-		c <- true
-	})
-
-	http.ListenAndServe(":7001", nil)
 }
 

--- a/login.go
+++ b/login.go
@@ -16,7 +16,7 @@ func executeLoginCommand(context *kingpin.ParseContext) error {
 	var url = "http://localhost:" + config.AuthServerPort
 
 	ch := make(chan bool)
-	go startAuthServer(ch)
+	go startAuthServer(ch, config)
 
 	fmt.Println("Opening url: " + url)
 	openWebsite(url)

--- a/main.go
+++ b/main.go
@@ -14,6 +14,13 @@ var (
 	buildDate       string
 	parsedBuildDate time.Time
 	gitHash         string
+
+	travixFirebaseApiKey            string
+	travixFirebaseAuthDomain        string
+	travixFirebaseDatabaseUrl       string
+	travixFirebaseStorageBucket     string
+	travixFirebaseMessagingSenderId string
+	travixDeveloperProfileUrl       string
 )
 
 // Although these are configuration values, they're not exposed to the public and are therefore kept internally.

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ func main() {
 	configureSubmitCommand(app)
 	configureVersionCommand(app)
 	configureWatchCommand(app)
+	configureWhoamiCommand(app)
 
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 }

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func main() {
 		BoolVar(&localFrontend)
 
 	configureInitCommand(app)
+	configureLoginCommand(app)
 	configurePushCommand(app)
 	configureSubmitCommand(app)
 	configureVersionCommand(app)

--- a/openWebsite.go
+++ b/openWebsite.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+func openWebsite(url string) error {
+	var err error
+	switch runtime.GOOS {
+	case "linux":
+		err = exec.Command("xdg-open", url).Start()
+	case "windows":
+		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	case "darwin":
+		err = exec.Command("open", url).Start()
+	default:
+		err = fmt.Errorf("unsupported platform")
+	}
+
+	return err
+}

--- a/push.go
+++ b/push.go
@@ -6,9 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"os/exec"
 	"regexp"
-	"runtime"
 	"time"
 
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -375,20 +373,4 @@ func getSessionID(appPath string) (string, error) {
 	}
 
 	return settings.SessionID, nil
-}
-
-func openWebsite(url string) error {
-	var err error
-	switch runtime.GOOS {
-	case "linux":
-		err = exec.Command("xdg-open", url).Start()
-	case "windows":
-		err = exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
-	case "darwin":
-		err = exec.Command("open", url).Start()
-	default:
-		err = fmt.Errorf("unsupported platform")
-	}
-
-	return err
 }

--- a/whoami.go
+++ b/whoami.go
@@ -39,9 +39,18 @@ func executeWhoamiCommand(context *kingpin.ParseContext) error {
 
 	tokenClient := &http.Client{}
 	var tokenReqPayload = []byte(`{"grant_type":"refresh_token","refresh_token": "` + refreshToken + `"}`)
-	tokenReq, _ := http.NewRequest("POST", "https://securetoken.googleapis.com/v1/token?key="+config.FirebaseApiKey, bytes.NewBuffer(tokenReqPayload))
+	tokenReq, tokenReqErr := http.NewRequest("POST", "https://securetoken.googleapis.com/v1/token?key="+config.FirebaseApiKey, bytes.NewBuffer(tokenReqPayload))
+	if tokenReqErr != nil {
+		log.Fatal(tokenReqErr)
+		return nil
+	}
+
 	tokenReq.Header.Set("Content-Type", "application/json")
-	tokenRes, _ := tokenClient.Do(tokenReq)
+	tokenRes, tokenResErr := tokenClient.Do(tokenReq)
+	if tokenResErr != nil {
+		log.Fatal(tokenResErr)
+		return nil
+	}
 
 	tokenBody := TokenBody{}
 	json.NewDecoder(tokenRes.Body).Decode(&tokenBody)
@@ -66,10 +75,19 @@ func executeWhoamiCommand(context *kingpin.ParseContext) error {
 	}
 
 	profileClient := &http.Client{}
-	profileReq, _ := http.NewRequest("GET", config.DeveloperProfileUrl+"/profile", nil)
+	profileReq, profileReqErr := http.NewRequest("GET", config.DeveloperProfileUrl+"/profile", nil)
+	if profileReqErr != nil {
+		log.Fatal(profileReqErr)
+		return nil
+	}
+
 	profileReq.Header.Set("Content-Type", "application/json")
 	profileReq.Header.Set("Authorization", tokenType+" "+tokenValue)
-	profileRes, _ := profileClient.Do(profileReq)
+	profileRes, profileResErr := profileClient.Do(profileReq)
+	if profileResErr != nil {
+		log.Fatal(profileResErr)
+		return nil
+	}
 
 	profileBody := ProfileBody{}
 	json.NewDecoder(profileRes.Body).Decode(&profileBody)

--- a/whoami.go
+++ b/whoami.go
@@ -11,7 +11,7 @@ import (
 )
 
 func configureWhoamiCommand(app *kingpin.Application) {
-	app.Command("whoami", "Displays logged in user's email address").
+	app.Command("whoami", "Displays logged in user's information").
 		Action(executeWhoamiCommand)
 }
 

--- a/whoami.go
+++ b/whoami.go
@@ -28,18 +28,18 @@ func executeWhoamiCommand(context *kingpin.ParseContext) error {
 
 	// fetch refreshed token
 	type TokenBody struct {
-		AccessToken string `json:"access_token"`
-		ExpiresIn string `json:"expires_in"`
-		IdToken string `json:"id_token"`
-		ProjectId string `json:"project_id"`
+		AccessToken  string `json:"access_token"`
+		ExpiresIn    string `json:"expires_in"`
+		IdToken      string `json:"id_token"`
+		ProjectId    string `json:"project_id"`
 		RefreshToken string `json:"refresh_token"`
-		TokenType string `json:"token_type"`
-		UserId string `json:"user_id"`
+		TokenType    string `json:"token_type"`
+		UserId       string `json:"user_id"`
 	}
 
 	tokenClient := &http.Client{}
 	var tokenReqPayload = []byte(`{"grant_type":"refresh_token","refresh_token": "` + refreshToken + `"}`)
-	tokenReq, _ := http.NewRequest("POST", "https://securetoken.googleapis.com/v1/token?key=" + config.FirebaseApiKey, bytes.NewBuffer(tokenReqPayload))
+	tokenReq, _ := http.NewRequest("POST", "https://securetoken.googleapis.com/v1/token?key="+config.FirebaseApiKey, bytes.NewBuffer(tokenReqPayload))
 	tokenReq.Header.Set("Content-Type", "application/json")
 	tokenRes, _ := tokenClient.Do(tokenReq)
 
@@ -51,24 +51,24 @@ func executeWhoamiCommand(context *kingpin.ParseContext) error {
 
 	// fetch profile
 	type Profile struct {
-		Email string
+		Email          string
 		FirebaseUserId string
-		Id int
-		IsEnabled bool
-		IsVerified bool
-		Name string
-		PublisherId string
+		Id             int
+		IsEnabled      bool
+		IsVerified     bool
+		Name           string
+		PublisherId    string
 	}
 
 	type ProfileBody struct {
 		HasProfile bool
-		Profile Profile
+		Profile    Profile
 	}
 
 	profileClient := &http.Client{}
-	profileReq, _ := http.NewRequest("GET", config.DeveloperProfileUrl + "/profile", nil)
+	profileReq, _ := http.NewRequest("GET", config.DeveloperProfileUrl+"/profile", nil)
 	profileReq.Header.Set("Content-Type", "application/json")
-	profileReq.Header.Set("Authorization", tokenType + " " + tokenValue)
+	profileReq.Header.Set("Authorization", tokenType+" "+tokenValue)
 	profileRes, _ := profileClient.Do(profileReq)
 
 	profileBody := ProfileBody{}

--- a/whoami.go
+++ b/whoami.go
@@ -10,6 +10,74 @@ import (
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 
+type TokenBody struct {
+	AccessToken  string `json:"access_token"`
+	ExpiresIn    string `json:"expires_in"`
+	IdToken      string `json:"id_token"`
+	ProjectId    string `json:"project_id"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+	UserId       string `json:"user_id"`
+}
+
+type Profile struct {
+	Email          string
+	FirebaseUserId string
+	Id             int
+	IsEnabled      bool
+	IsVerified     bool
+	Name           string
+	PublisherId    string
+}
+
+type ProfileBody struct {
+	HasProfile bool
+	Profile    Profile
+}
+
+func fetchRefreshedToken(config Config, refreshToken string) (TokenBody, error) {
+	tokenClient := &http.Client{}
+	var tokenReqPayload = []byte(`{"grant_type":"refresh_token","refresh_token": "` + refreshToken + `"}`)
+	tokenReq, tokenReqErr := http.NewRequest("POST", "https://securetoken.googleapis.com/v1/token?key="+config.FirebaseApiKey, bytes.NewBuffer(tokenReqPayload))
+	if tokenReqErr != nil {
+		return TokenBody{}, tokenReqErr
+	}
+
+	tokenReq.Header.Set("Content-Type", "application/json")
+	tokenRes, tokenResErr := tokenClient.Do(tokenReq)
+	if tokenResErr != nil {
+		return TokenBody{}, tokenResErr
+	}
+
+	tokenBody := TokenBody{}
+	json.NewDecoder(tokenRes.Body).Decode(&tokenBody)
+
+	return tokenBody, nil
+}
+
+func fetchDeveloperProfile(config Config, tokenBody TokenBody) (ProfileBody, error) {
+	tokenType := tokenBody.TokenType
+	tokenValue := tokenBody.IdToken
+
+	profileClient := &http.Client{}
+	profileReq, profileReqErr := http.NewRequest("GET", config.DeveloperProfileUrl+"/profile", nil)
+	if profileReqErr != nil {
+		return ProfileBody{}, profileReqErr
+	}
+
+	profileReq.Header.Set("Content-Type", "application/json")
+	profileReq.Header.Set("Authorization", tokenType+" "+tokenValue)
+	profileRes, profileResErr := profileClient.Do(profileReq)
+	if profileResErr != nil {
+		return ProfileBody{}, profileResErr
+	}
+
+	profileBody := ProfileBody{}
+	json.NewDecoder(profileRes.Body).Decode(&profileBody)
+
+	return profileBody, nil
+}
+
 func configureWhoamiCommand(app *kingpin.Application) {
 	app.Command("whoami", "Displays logged in user's information").
 		Action(executeWhoamiCommand)
@@ -18,79 +86,27 @@ func configureWhoamiCommand(app *kingpin.Application) {
 func executeWhoamiCommand(context *kingpin.ParseContext) error {
 	config := GetConfig()
 
+	// get locally stored auth info
 	auth, authErr := GetAuth(config)
 	if authErr != nil {
 		log.Fatal(authErr)
 		return nil
 	}
 
-	refreshToken := auth.User.StsTokenManager.RefreshToken
-
 	// fetch refreshed token
-	type TokenBody struct {
-		AccessToken  string `json:"access_token"`
-		ExpiresIn    string `json:"expires_in"`
-		IdToken      string `json:"id_token"`
-		ProjectId    string `json:"project_id"`
-		RefreshToken string `json:"refresh_token"`
-		TokenType    string `json:"token_type"`
-		UserId       string `json:"user_id"`
-	}
-
-	tokenClient := &http.Client{}
-	var tokenReqPayload = []byte(`{"grant_type":"refresh_token","refresh_token": "` + refreshToken + `"}`)
-	tokenReq, tokenReqErr := http.NewRequest("POST", "https://securetoken.googleapis.com/v1/token?key="+config.FirebaseApiKey, bytes.NewBuffer(tokenReqPayload))
-	if tokenReqErr != nil {
-		log.Fatal(tokenReqErr)
+	refreshToken := auth.User.StsTokenManager.RefreshToken
+	tokenBody, tokenBodyErr := fetchRefreshedToken(config, refreshToken)
+	if tokenBodyErr != nil {
+		log.Fatal(tokenBodyErr)
 		return nil
 	}
-
-	tokenReq.Header.Set("Content-Type", "application/json")
-	tokenRes, tokenResErr := tokenClient.Do(tokenReq)
-	if tokenResErr != nil {
-		log.Fatal(tokenResErr)
-		return nil
-	}
-
-	tokenBody := TokenBody{}
-	json.NewDecoder(tokenRes.Body).Decode(&tokenBody)
-
-	tokenType := tokenBody.TokenType
-	tokenValue := tokenBody.IdToken
 
 	// fetch profile
-	type Profile struct {
-		Email          string
-		FirebaseUserId string
-		Id             int
-		IsEnabled      bool
-		IsVerified     bool
-		Name           string
-		PublisherId    string
-	}
-
-	type ProfileBody struct {
-		HasProfile bool
-		Profile    Profile
-	}
-
-	profileClient := &http.Client{}
-	profileReq, profileReqErr := http.NewRequest("GET", config.DeveloperProfileUrl+"/profile", nil)
-	if profileReqErr != nil {
-		log.Fatal(profileReqErr)
+	profileBody, profileBodyErr := fetchDeveloperProfile(config, tokenBody)
+	if profileBodyErr != nil {
+		log.Fatal(profileBodyErr)
 		return nil
 	}
-
-	profileReq.Header.Set("Content-Type", "application/json")
-	profileReq.Header.Set("Authorization", tokenType+" "+tokenValue)
-	profileRes, profileResErr := profileClient.Do(profileReq)
-	if profileResErr != nil {
-		log.Fatal(profileResErr)
-		return nil
-	}
-
-	profileBody := ProfileBody{}
-	json.NewDecoder(profileRes.Body).Decode(&profileBody)
 
 	if profileBody.HasProfile {
 		fmt.Println("Email: " + profileBody.Profile.Email)

--- a/whoami.go
+++ b/whoami.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
@@ -21,10 +23,30 @@ func executeWhoamiCommand(context *kingpin.ParseContext) error {
 		return nil
 	}
 
-	email := auth.User.Email
+	accessToken := auth.Credential.AccessToken
 
-	// @TODO: verify by pinging server
-	fmt.Println(email)
+	type UserInfo struct {
+		Email string
+		FamilyName string
+		Gender string
+		GivenName string
+		Hd string
+		Id string
+		Link string
+		Locale string
+		Name string
+		Picture string
+		VerifiedEmail string
+	}
+
+	client := &http.Client{}
+	req, _ := http.NewRequest("GET", "https://www.googleapis.com/oauth2/v1/userinfo?alt=json", nil)
+	req.Header.Set("Authorization", "Bearer " + accessToken)
+	res, _ := client.Do(req)
+
+	userInfo := UserInfo{}
+	json.NewDecoder(res.Body).Decode(&userInfo)
+	fmt.Println(userInfo.Email)
 
 	return nil
 }

--- a/whoami.go
+++ b/whoami.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+)
+
+func configureWhoamiCommand(app *kingpin.Application) {
+	app.Command("whoami", "Displays logged in user's email address").
+		Action(executeWhoamiCommand)
+}
+
+func executeWhoamiCommand(context *kingpin.ParseContext) error {
+	config := GetConfig()
+
+	auth, authErr := GetAuth(config)
+	if authErr != nil {
+		log.Fatal(authErr)
+		return nil
+	}
+
+	email := auth.User.Email
+
+	// @TODO: verify by pinging server
+	fmt.Println(email)
+
+	return nil
+}


### PR DESCRIPTION
## What's done

User can now login and verify themselves:

```
$ appix login
```

^-- would open up the browser and User can sign in with their Google account.

Once signed in, User can check their login status via `appix whoami` command:

<img width="794" alt="screen shot 2016-11-22 at 14 27 08" src="https://cloud.githubusercontent.com/assets/20046/20528559/01ccf63e-b0cd-11e6-8dc9-89c4cc682eea.png">

^-- shows information from DeveloperProfile service for logged in user

Docs added targetting maintainers and for developers of the ADK in README.

## Development set up

Only applicable to those developing the ADK itself.

### Environment variables

Make sure you have these environment variables (usually in your `~/.bash_profile` file) with the correct values:

```
export TRAVIX_FIREBASE_API_KEY=""
export TRAVIX_FIREBASE_AUTH_DOMAIN=""
export TRAVIX_FIREBASE_DATABASE_URL=""
export TRAVIX_FIREBASE_STORAGE_BUCKET=""
export TRAVIX_FIREBASE_MESSAGING_SENDER_ID=""

export TRAVIX_DEVELOPER_PROFILE_URL=""
```

### Build

Running this would generate `./bin/appix-mac` (if you are on macOS):

```
$ ./build.sh
```

Furthermore, you can copy it to the local appix path for easy access:

```
$ cp ./bin/appix-mac ~/.appix/appix
```

Now you can execute it as `$ appix` as usual.

## Travis-CI

Travis has been configured with the production environment variables here: https://travis-ci.org/Travix-International/Travix.Core.Adk/settings

## Possible stories in future

* Logging out
* Pass bearer token in requests to our Services requiring authorization
* Lots of clean up