### PR TITLE
Refresh the token only if it's near expiry

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1,5 +1,7 @@
 package auth
 
+import "time"
+
 // Auth structs
 type StsTokenManager struct {
 	ApiKey         string
@@ -28,17 +30,19 @@ type AuthCredential struct {
 type AuthData struct {
 	User       AuthUser
 	Credential AuthCredential
+	Token      TokenBody
 }
 
 // Token structs
 type TokenBody struct {
-	AccessToken  string `json:"access_token"`
-	ExpiresIn    string `json:"expires_in"`
-	IdToken      string `json:"id_token"`
-	ProjectId    string `json:"project_id"`
-	RefreshToken string `json:"refresh_token"`
-	TokenType    string `json:"token_type"`
-	UserId       string `json:"user_id"`
+	AccessToken  string    `json:"access_token"`
+	ExpiresIn    string    `json:"expires_in"`
+	ExpiresAt    time.Time `json:"expires_at"`
+	IdToken      string    `json:"id_token"`
+	ProjectId    string    `json:"project_id"`
+	RefreshToken string    `json:"refresh_token"`
+	TokenType    string    `json:"token_type"`
+	UserId       string    `json:"user_id"`
 }
 
 // Profile structs

--- a/lib/auth/refresh_token.go
+++ b/lib/auth/refresh_token.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"strconv"
+	"time"
 )
 
 func (auth *AuthData) RefreshToken(firebaseApiKey string) (TokenBody, error) {
@@ -24,6 +26,10 @@ func (auth *AuthData) RefreshToken(firebaseApiKey string) (TokenBody, error) {
 
 	tokenBody := TokenBody{}
 	json.NewDecoder(tokenRes.Body).Decode(&tokenBody)
+
+	// The api only returns the ExpiresIn field, but in later stages we need to know the actual Time when it is expiring.
+	expiresIn, _ := strconv.Atoi(tokenBody.ExpiresIn)
+	tokenBody.ExpiresAt = time.Now().UTC().Add(time.Duration(expiresIn) * time.Second)
 
 	return tokenBody, nil
 }

--- a/lib/auth/store_auth.go
+++ b/lib/auth/store_auth.go
@@ -6,7 +6,7 @@ import (
 	"log"
 )
 
-func GetAuthData(authFilePath string) (*AuthData, error) {
+func ReadAuthData(authFilePath string) (*AuthData, error) {
 	content, readErr := ioutil.ReadFile(authFilePath)
 	if readErr != nil {
 		return nil, readErr
@@ -21,4 +21,19 @@ func GetAuthData(authFilePath string) (*AuthData, error) {
 	}
 
 	return &auth, nil
+}
+
+func SaveAuthData(authFilePath string, data *AuthData) error {
+	content, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(authFilePath, content, 0644)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/lib/cmd/whoami/whoami.go
+++ b/lib/cmd/whoami/whoami.go
@@ -56,6 +56,7 @@ func (cmd *WhoamiCommand) Register(context context.Context) {
 				fmt.Println("Publisher ID: " + profileBody.Profile.PublisherId)
 			} else {
 				fmt.Println("No profile found.")
+				fmt.Println("Please log in at https://developerportal.travix.com/ to create a developer profile.")
 			}
 
 			return nil


### PR DESCRIPTION
Two things changed:

 - With `appix whoami`, if the user doesn't have a profile yet, we print a message saying they should log in in the developer portal.
 - Token refresh: we store the actual access token with the authentication data, and we only refresh it if it is less than 5 minutes from expiry.