### PR TITLE
Adjust the install scripts to the extended Json response of Github

### DIFF
--- a/appixinstall.ps1
+++ b/appixinstall.ps1
@@ -115,14 +115,14 @@ if ([string]::IsNullOrEmpty($appixVersion)){
   $reader = New-Object System.IO.StreamReader $outputStream
   $content = $reader.ReadToEnd()
 
-  # The releases are returned in the format {"id":3622206,"tag_name":"hello-1.0.0.11"}, we have to extract the tag_name.
-  $content -match '.*"tag_name":"(.*)".*' | Out-Null
-  $latestVersion = $Matches[1]
+  # The releases are returned in a json like {... "tag_name":"hello-1.0.0.11", ...}, we have to extract the tag_name.
+  $json = $content | ConvertFrom-Json
+  $latestVersion = $json.tag_name
   $url = "https://github.com/Travix-International/Travix.Core.Adk/releases/download/$latestVersion/appix.exe"
 }
 else {
   # The version was explicitly specified
-  $url = "https://github.com/Travix-International/Travix.Core.Adk/releases/download/appix-$appixVersion/appix.exe"
+  $url = "https://github.com/Travix-International/Travix.Core.Adk/releases/download/$appixVersion/appix.exe"
 }
 
 # We install into ~/.appix

--- a/appixinstall.sh
+++ b/appixinstall.sh
@@ -40,12 +40,12 @@ if [ -z "$APPIX_BIN_URL" ]; then
         RELEASES=$(curl -L -s -H 'Accept: application/json' https://github.com/Travix-International/Travix.Core.Adk/releases/latest)
 
         # The releases are returned in the format {"id":3622206,"tag_name":"hello-1.0.0.11"}, we have to extract the tag_name.
-        LATEST_VERISION=$(echo $RELEASES | sed -e 's/.*"tag_name":"\(.*\)".*/\1/')
+        LATEST_VERISION=$(echo $RELEASES | sed -e 's/.*"tag_name":"\([^"]*\)".*/\1/')
 
         APPIX_BIN_URL="https://github.com/Travix-International/Travix.Core.Adk/releases/download/$LATEST_VERISION/$APPIX_BIN_NAME"
     else
         # Get specific version
-        APPIX_BIN_URL="https://github.com/Travix-International/Travix.Core.Adk/releases/download/appix-$APPIX_VERSION/$APPIX_BIN_NAME"
+        APPIX_BIN_URL="https://github.com/Travix-International/Travix.Core.Adk/releases/download/$APPIX_VERSION/$APPIX_BIN_NAME"
     fi
 fi
 


### PR DESCRIPTION
The response used to be
```
{"id":3622206,"tag_name":"hello-1.0.0.11"}
```
And the regex we used to get the version number was: `.*"tag_name":"(.*)".*`
Now the response was extended with additional properties.
```
{"id":4849269,"tag_name":"1.1.3","update_url":"...", ...}
```
And our regex was matching more then it should, so I modified it to match only until the first double quotes: `.*"tag_name":"([^"]*)".*`